### PR TITLE
Fix notifications and use higher quality images

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -17,6 +17,8 @@
 		[{
 			"matches"	: 
 			[
+				"*://*.hangouts.google.com/*",
+				"*://hangouts.google.com/*",
 				"*://*.talkgadget.google.com/*",
 				"*://talkgadget.google.com/*"
 			],
@@ -33,6 +35,8 @@
 		],
 	"permissions"		:
 		[
+			"*://*.hangouts.google.com/*",
+			"*://hangouts.google.com/*",
 			"*://*.talkgadget.google.com/*",
 			"*://talkgadget.google.com/*",
 			"tabs",

--- a/extension/tool/smuggler.js
+++ b/extension/tool/smuggler.js
@@ -27,18 +27,21 @@ $(document).ready(function(){
 /**
  * Counting difference in divs.
  */
-n=-1;
-divno=-1;
+var divno=-1;
+var divs = {};
 function check_new_message(){
-  if(n==-1){
-    n= $("div").length;
+  var name = $('div.Ob2Lud.RE.EIhiV.OxDpJ').text();
+  if(name !== '' && !divs[name]) {
+    divs[name] = $("div").length;
   }
-  divno  = $("div").length;
+  var n = divs[name];
+  divno = $("div").length;
+  
   if(divno>n && n!==0){
     if(!window_focus){
       update_notifier();
     }
-    n=divno;
+    divs[name]=divno;
   }
 }
 /**
@@ -46,22 +49,25 @@ function check_new_message(){
  */
 function update_notifier(){
 
+  var div = $('div.tk.Sn:last');
+  
   /**
    * Thumbnail.
    */
-  var allThumbs  = $('img').filter(function(){
-    return ($(this).width() ==32) && ($(this).height() ==32)
-  });
-  var reqThumb  = allThumbs[allThumbs.length-1].src;
-
+  var allThumbs = $(div).find('img.Yf');
+  var reqThumb  = allThumbs.length > 0 ? allThumbs[allThumbs.length-1].src : '';
+  reqThumb = reqThumb.replace(/\/s32-/, '/s256-');
+  
   /**
    * Message.
    */
-  var message  = $('div.Mu.SP:last').text();
+  var message  = $(div).find('.Mu.SP:last').text();
 
   /**
    * User.
    */
-  var user  = $('div.UR.UG:last').text();
-  chrome.extension.sendRequest({img: reqThumb, user: user,update: message,url: document.referrer});
+  var user  = $(div).find('.UR.UG').text();
+  
+  if (user !== '')
+    chrome.runtime.sendMessage({img: reqThumb, user: user,update: message,url: document.referrer});
 }


### PR DESCRIPTION
I've reworked a lot of the code to work with the new version of hangouts.
- Added permission for `hangouts.google.com`
- Div counts are stored in a hash array based on the user's display name (using selector `div.Ob2Lud.RE.EIhiV.OxDpJ`). I ran into a lot of conflicts when I had multiple chat windows open and this seemed like the best way to handle it.
- `chrome.extension.onRequest` and `chrome.extension.sendRequest` were deprecated many versions ago, and have been replaced with `chrome.runtime.onMessage` and `chrome.runtime.sendMessage` in recent versions of Chrome.
- Added checks against `chrome.runtime.lastError`. Chrome would throw fatal errors if these checks were not performed.
- Replaced deprecated `webkitNotifications.createNotification` call with one to the official HTML5 Notification API
- Try to use 256x256 image instead of 32x32
- Addressed issue #2 (it was failing when there were no images found)
